### PR TITLE
bug/ICS-204 domains not cached

### DIFF
--- a/packages/credential-governance/src/constants.ts
+++ b/packages/credential-governance/src/constants.ts
@@ -2,6 +2,5 @@ import { utils } from 'ethers';
 
 const { parseEther } = utils;
 
-export const emptyAddress = '0x0000000000000000000000000000000000000000';
 export const PRINCIPAL_THRESHOLD = parseEther('100');
 export const WITHDRAW_DELAY = 5;

--- a/packages/credential-governance/src/domain-hierarchy.ts
+++ b/packages/credential-governance/src/domain-hierarchy.ts
@@ -1,36 +1,38 @@
-import { EventFilter, utils, providers } from 'ethers';
+import { EventFilter, utils, providers, constants } from 'ethers';
 import { ENSRegistry } from '../ethers/ENSRegistry';
 import { ENSRegistry__factory } from '../ethers/factories/ENSRegistry__factory';
 import { abi as ensRegistryContract } from '../build/contracts/ENS.json';
-import { abi as ensResolverContract } from '../build/contracts/PublicResolver.json';
+import { abi as resolverContract } from '../build/contracts/RoleDefinitionResolverV2.json';
 import { abi as domainNotifierContract } from '../build/contracts/DomainNotifier.json';
-import { emptyAddress } from './constants';
 import { DomainReader } from './domain-reader';
-import { PublicResolver__factory } from '../ethers/factories/PublicResolver__factory';
 import { DomainNotifier__factory } from '../ethers/factories/DomainNotifier__factory';
-import { PublicResolver } from '../ethers/PublicResolver';
 import { DomainNotifier } from '../ethers/DomainNotifier';
 import { Result } from '@ethersproject/abi';
+import { RoleDefinitionResolverV2 } from '../ethers/RoleDefinitionResolverV2';
+import { RoleDefinitionResolverV2__factory } from '../ethers/factories/RoleDefinitionResolverV2__factory';
+
+const { namehash } = utils;
+const { AddressZero } = constants;
 
 export class DomainHierarchy {
   protected readonly _domainReader: DomainReader;
   protected readonly _ensRegistry: ENSRegistry;
   protected readonly _provider: providers.Provider;
   protected readonly _domainNotifier: DomainNotifier;
-  protected readonly _publicResolver?: PublicResolver;
+  private _resolver?: RoleDefinitionResolverV2;
 
   constructor({
     domainReader,
     ensRegistryAddress,
     provider,
     domainNotifierAddress,
-    publicResolverAddress,
+    resolverAddress,
   }: {
     domainReader: DomainReader;
     ensRegistryAddress: string;
     provider: providers.Provider;
     domainNotifierAddress: string;
-    publicResolverAddress?: string;
+    resolverAddress?: string;
   }) {
     if (!domainReader) throw new Error('You need to pass a DomainReader');
     this._domainReader = domainReader;
@@ -53,19 +55,19 @@ export class DomainHierarchy {
       provider
     );
 
-    if (publicResolverAddress) {
-      this._publicResolver = PublicResolver__factory.connect(
-        publicResolverAddress,
+    if (resolverAddress) {
+      this._resolver = RoleDefinitionResolverV2__factory.connect(
+        resolverAddress,
         provider
       );
     }
   }
 
   /**
-   * Retrieves list of subdomains from on-chain for a given parent domain
-   * based on the logs from the ENS resolver contracts.
+   * Retrieves subdomains of given root domain based on the logs from the ENS resolver contract.
+   * Omits metadomains 'orgs', 'apps' and 'roles'. Non-owned domains and domains for which no resolver is set are also omitted
    * By default, queries from the DomainNotifier contract.
-   * If publicResolver available, also queries from PublicResolver contract.
+   * Also queries role resolver if it is avalilable.
    */
   public getSubdomainsUsingResolver = async ({
     domain,
@@ -77,10 +79,9 @@ export class DomainHierarchy {
     if (!domain) throw new Error('You need to pass a domain name');
 
     // Filter out apps and roles
-    const isRelevantDomainEndings = (name: string) => {
-      const notRelevantDomainEndings = ['roles', 'apps'];
-      const leafLabel = name.split('.')[0];
-      return notRelevantDomainEndings.includes(leafLabel);
+    const isMetadomain = (name: string) => {
+      const label = name.split('.')[0];
+      return ['roles', 'apps', 'orgs'].includes(label);
     };
 
     if (mode === 'ALL') {
@@ -88,13 +89,14 @@ export class DomainHierarchy {
         return async ({ node }: Result) => {
           try {
             const name = await nameReader(node);
-            if (isRelevantDomainEndings(name)) {
+            if (isMetadomain(name)) {
               return '';
             }
 
             if (name.endsWith(domain) && name !== domain) {
               const owner = await this._ensRegistry.owner(node);
-              if (owner === emptyAddress) return '';
+              const resolver = await this._ensRegistry.resolver(node);
+              if (owner === AddressZero || resolver === AddressZero) return '';
               return name;
             }
           } catch {
@@ -104,24 +106,21 @@ export class DomainHierarchy {
           return '';
         };
       };
+
       let subDomains = await this.getDomainsFromLogs({
         parser: getParser(this._domainReader.readName.bind(this._domainReader)),
         provider: this._domainNotifier.provider,
         event: this._domainNotifier.filters.DomainUpdated(null),
         contractInterface: new utils.Interface(domainNotifierContract),
       });
-      if (this._publicResolver) {
-        const publicResolverDomains = await this.getDomainsFromLogs({
-          parser: getParser(this._publicResolver.name),
-          provider: this._publicResolver.provider,
-          event: this._publicResolver.filters.TextChanged(
-            null,
-            'metadata',
-            null
-          ),
-          contractInterface: new utils.Interface(ensResolverContract),
+      if (this._resolver) {
+        const resolverDomains = await this.getDomainsFromLogs({
+          parser: getParser(this._resolver.name),
+          provider: this._resolver.provider,
+          event: this._resolver.filters.TextChanged(null, 'metadata', null),
+          contractInterface: new utils.Interface(resolverContract),
         });
-        subDomains = new Set([...publicResolverDomains, ...subDomains]);
+        subDomains = new Set([...resolverDomains, ...subDomains]);
       }
       return [...subDomains].filter(Boolean); // Boolean filter to remove empty string
     }
@@ -133,15 +132,15 @@ export class DomainHierarchy {
         null
       ),
       parser: async ({ node, label, owner }) => {
-        if (owner === emptyAddress) return '';
+        if (owner === AddressZero) return '';
         const namehash = utils.keccak256(node + label.slice(2));
         try {
           const [name, ownerAddress] = await Promise.all([
             this._domainReader.readName(namehash),
             this._ensRegistry.owner(namehash),
           ]);
-          if (ownerAddress === emptyAddress) return '';
-          if (isRelevantDomainEndings(name)) {
+          if (ownerAddress === AddressZero) return '';
+          if (isMetadomain(name)) {
             return '';
           }
           return name;
@@ -169,13 +168,13 @@ export class DomainHierarchy {
     const notRelevantDomainEndings = ['roles', 'apps'];
     const parser = async ({ node, label, owner }: Result) => {
       try {
-        if (owner === emptyAddress) return '';
+        if (owner === AddressZero) return '';
         const namehash = utils.keccak256(node + label.slice(2));
         const [name, ownerAddress] = await Promise.all([
           this._domainReader.readName(namehash),
           this._ensRegistry.owner(namehash),
         ]);
-        if (ownerAddress === emptyAddress) return '';
+        if (ownerAddress === AddressZero) return '';
         return name;
       } catch {
         // A possible source of exceptions is if domain has been deleted (https://energyweb.atlassian.net/browse/SWTCH-997)

--- a/packages/credential-governance/test/domain-hierarchy-volta-test.ts
+++ b/packages/credential-governance/test/domain-hierarchy-volta-test.ts
@@ -3,6 +3,7 @@ import {
   VOLTA_DOMAIN_NOTIFER_ADDRESS,
   VOLTA_ENS_REGISTRY_ADDRESS,
   VOLTA_PUBLIC_RESOLVER_ADDRESS,
+  VOLTA_RESOLVER_V2_ADDRESS,
 } from '../src/chain-constants';
 import { DomainHierarchy } from '../src/domain-hierarchy';
 import { DomainReader } from '../src';
@@ -26,7 +27,7 @@ xdescribe('[DomainHierarchy VOLTA]', async function () {
     ensRegistryAddress: VOLTA_ENS_REGISTRY_ADDRESS,
     provider,
     domainNotifierAddress: VOLTA_DOMAIN_NOTIFER_ADDRESS,
-    publicResolverAddress: VOLTA_PUBLIC_RESOLVER_ADDRESS,
+    resolverAddress: VOLTA_RESOLVER_V2_ADDRESS,
   });
 
   const domain = 'iam.ewc';


### PR DESCRIPTION
This fixes one of the reasons of https://energyweb.atlassian.net/browse/ICS-204

Domains will be read from RoleResolverV2 as we not using PublicResolver any more. Or may be configure this depending on chain?