### PR TITLE
feat(issuer-resolver): use domain reader to resolve issuers

### DIFF
--- a/packages/vc-verification/src/issuer-def-resolver.ts
+++ b/packages/vc-verification/src/issuer-def-resolver.ts
@@ -42,10 +42,12 @@ export class EthersProviderIssuerDefinitionResolver
     const resolvedNamespace = namespace.startsWith('0x')
       ? namespace
       : utils.namehash(namespace);
-    const roleDefinition = (await this._domainReader.read({
+    const roleDefinition = await this._domainReader.read({
       node: resolvedNamespace,
-    })) as IRoleDefinitionV2;
-    if (roleDefinition) return roleDefinition.issuer;
+    });
+    if (DomainReader.isRoleDefinitionV2(roleDefinition)) {
+      return roleDefinition.issuer;
+    }
     return undefined;
   }
 }


### PR DESCRIPTION
This PR makes changes to the issuers resolution code to consume `DomainReader` instead of `RoleDefinitionResolver`.