### PR TITLE
chore: add and export VC types from credential-governance package

### DIFF
--- a/packages/credential-governance/package.json
+++ b/packages/credential-governance/package.json
@@ -62,6 +62,7 @@
     "@ethersproject/abi": "^5.4.0",
     "@ethersproject/abstract-signer": "^5.4.1",
     "@ew-did-registry/proxyidentity": "0.6.2",
+    "@ew-did-registry/credentials-interface": "0.6.3-alpha.527.0",
     "@openzeppelin/contracts": "4.3.3",
     "@openzeppelin/contracts-upgradeable": "4.3.3",
     "@openzeppelin/truffle-upgrades": "1.12.0",

--- a/packages/credential-governance/src/index.ts
+++ b/packages/credential-governance/src/index.ts
@@ -14,6 +14,7 @@ import {
   IIssuerDefinition,
   IRevokerDefinition,
 } from './types/domain-definitions';
+import { RoleCredentialSubject, IssuerFields } from './types/role-credential';
 import { ResolverContractType } from './types/resolver-contract-type';
 import { EncodedCall } from './types/transaction';
 
@@ -35,6 +36,7 @@ export {
   IIssuerDefinition,
   IRevokerDefinition,
 };
+export { RoleCredentialSubject, IssuerFields };
 export { EncodedCall };
 export * from './chain-constants';
 export { PRINCIPAL_THRESHOLD, WITHDRAW_DELAY } from './constants';

--- a/packages/credential-governance/src/types/role-credential.ts
+++ b/packages/credential-governance/src/types/role-credential.ts
@@ -1,0 +1,21 @@
+import {
+    CredentialSubject,
+  } from '@ew-did-registry/credentials-interface';
+
+export interface IssuerFields {
+    key: string;
+    value: string | number;
+  }
+  
+  export interface RoleCredentialSubject extends CredentialSubject {
+    /*
+     * https://www.w3.org/TR/vc-data-model/#identifiers
+     */
+    id: string;
+  
+    role: {
+      namespace: string;
+      version: string;
+    };
+    issuerFields: IssuerFields[];
+  }


### PR DESCRIPTION
- Adds and exports RoleCredentialSubject, IssuerFields interfaces from credential governance types