### PR TITLE
task/EC-56 different domains from resolver and registry

### DIFF
--- a/packages/credential-governance/test/domain-hierarchy-testsuite.ts
+++ b/packages/credential-governance/test/domain-hierarchy-testsuite.ts
@@ -162,8 +162,8 @@ export function domainHierarchyTestSuite(): void {
     describe('getSubdomainsUsingResolver', () => {
       it('returns subdomains using RoleDefResolver', async () => {
         await Promise.all([
-          addSubdomain('ewc', 'test', 'ROLEDEF'),
-          addSubdomain('ewc', 'iam', 'ROLEDEF'),
+          addSubdomain(domain, 'test', 'ROLEDEF'),
+          addSubdomain(domain, 'iam', 'ROLEDEF'),
         ]);
         const subDomains = await domainHierarchy.getSubdomainsUsingResolver({
           domain: domain,
@@ -272,13 +272,13 @@ export function domainHierarchyTestSuite(): void {
     describe('getSubdomainsUsingRegistry', () => {
       it('returns subdomains', async () => {
         await Promise.all([
-          addSubdomain('ewc', 'test', 'ROLEDEF'),
-          addSubdomain('ewc', 'iam', 'ROLEDEF'),
+          addSubdomain(domain, 'test', 'ROLEDEF'),
+          addSubdomain(domain, 'iam', 'ROLEDEF'),
         ]);
         const subDomains = await domainHierarchy.getSubdomainsUsingRegistry({
           domain: domain,
         });
-        expect(subDomains.length).to.equal(3);
+        expect(subDomains.length).to.equal(2);
       });
 
       it("continues even if domain isn't registered", async () => {
@@ -294,7 +294,7 @@ export function domainHierarchyTestSuite(): void {
         const subDomains = await domainHierarchy.getSubdomainsUsingRegistry({
           domain: domain,
         });
-        expect(subDomains.length).to.equal(2);
+        expect(subDomains.length).to.equal(1);
       });
     });
 

--- a/packages/credential-governance/test/domain-hierarchy-volta-test.ts
+++ b/packages/credential-governance/test/domain-hierarchy-volta-test.ts
@@ -51,13 +51,13 @@ xdescribe('[DomainHierarchy VOLTA]', async function () {
 
   it('domains from registry should include domains from resolver', async () => {
     expect(
+      await domainHierarchy.getSubdomainsUsingRegistry({
+        domain: domain,
+      })
+    ).to.include.members(
       await domainHierarchy.getSubdomainsUsingResolver({
         domain: domain,
         mode: 'ALL',
-      })
-    ).to.include.members(
-      await domainHierarchy.getSubdomainsUsingRegistry({
-        domain: domain,
       })
     );
   });


### PR DESCRIPTION
Fixes

- not include parent in subdomains from registry
- domain always read from domain reader

Also simplified getting from registry. Queueing of domains is not necessary, because queue always consists from one element