### PR TITLE
fix(exp): update documentation to reflect expiry in milliseconds

### DIFF
--- a/packages/credential-governance/src/types/domain-definitions.ts
+++ b/packages/credential-governance/src/types/domain-definitions.ts
@@ -25,7 +25,7 @@ export interface IRoleDefinitionV2 extends IRoleDefinitionText {
   issuer: IIssuerDefinition;
   revoker: IRevokerDefinition;
   enrolmentPreconditions: { type: PreconditionType; conditions: string[] }[];
-  // Default seconds value after which the role is considered expired, if empty then no expiry
+  // Default time period in milliseconds, after which the role is considered expired. If null or undefined, there is no default expiry
   defaultValidityPeriod?: number;
 }
 

--- a/packages/onchain-claims/test/test_utils/role-utils.ts
+++ b/packages/onchain-claims/test/test_utils/role-utils.ts
@@ -6,7 +6,7 @@ import { ClaimsRevocationRegistry as RevocationRegistry } from '../../ethers/Cla
 const { solidityKeccak256, defaultAbiCoder, arrayify } = utils;
 
 export const defaultVersion = 1;
-const expiry = Math.floor(new Date().getTime() / 1000) + 60 * 60;
+const expiry = new Date().getTime() + 60 * 60;
 // set it manually because ganache returns chainId same as network utils.id
 const chainId = 73799;
 const provider = new JsonRpcProvider('http://localhost:8544');


### PR DESCRIPTION
- Update defaultValidityPeriod documentation to make clear that time period is measured in milliseconds. (I think this is what this task was for but could be missing something!)