### PR TITLE
Change requestorFields from object to array of objects

### DIFF
--- a/packages/vc-verification/src/models/credentials-types.ts
+++ b/packages/vc-verification/src/models/credentials-types.ts
@@ -14,9 +14,7 @@ export const verificationResult = function (
 };
 
 export interface ClaimData {
-  requestorFields: {
-    [key: string]: string | number;
-  };
+  requestorFields?: { key: string; value: string | number }[];
   claimType: string;
   claimTypeVersion: number;
 }


### PR DESCRIPTION
This is to be consistent with how `requestorFields` are used in iam-lib https://github.com/energywebfoundation/iam-client-lib/blob/561a583fdcd9ebc6b154983748317ec0b1749214/src/modules/claims/claims.types.ts#L164