### PR TITLE
fix: specify role in Credential Not Found error

### DIFF
--- a/packages/vc-verification/src/verifier/issuer-verification.ts
+++ b/packages/vc-verification/src/verifier/issuer-verification.ts
@@ -88,7 +88,7 @@ export class IssuerVerification {
         issuers?.roleName
       );
       if (!issuerCredential) {
-        return verificationResult(false, ERRORS.NoCredential);
+        return verificationResult(false, `${ERRORS.NoCredential} for role ${issuers?.roleName}`);
       }
       const revocationStatusResult =
         await this.revocationVerification.checkRevocationStatus(issuer, role);

--- a/packages/vc-verification/src/verifier/issuer-verification.ts
+++ b/packages/vc-verification/src/verifier/issuer-verification.ts
@@ -88,7 +88,10 @@ export class IssuerVerification {
         issuers?.roleName
       );
       if (!issuerCredential) {
-        return verificationResult(false, `${ERRORS.NoCredential} for role ${issuers?.roleName}`);
+        return verificationResult(
+          false,
+          `${ERRORS.NoCredential} for role ${issuers?.roleName}`
+        );
       }
       const revocationStatusResult =
         await this.revocationVerification.checkRevocationStatus(issuer, role);


### PR DESCRIPTION
- For https://energyweb.atlassian.net/jira/software/projects/SWTCH/boards/54?selectedIssue=SWTCH-1455, we want the user to be aware of the role that they need to have in order to be able to approve a role (if approval is role-based). Returning the role in this error is the first step, as ICL is not aware of what role is being checked for/not found by ew-credentials (check is being performed here:https://github.com/energywebfoundation/iam-client-lib/blob/2c0a860c7e11b9fb833ddbed71e2adf51229987b/src/modules/claims/claims.service.ts#L474) 