### PR TITLE
fix: remove carat from ew-did-registry packages

### DIFF
--- a/packages/credential-governance/package.json
+++ b/packages/credential-governance/package.json
@@ -54,14 +54,14 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
-    "@ew-did-registry/did": "^0.7.1-alpha.795.0",
+    "@ew-did-registry/credentials-interface": "0.7.1-alpha.795.0",
+    "@ew-did-registry/did": "0.7.1-alpha.795.0",
     "ethers": "^5.7.0"
   },
   "devDependencies": {
     "@ensdomains/buffer": "0.0.13",
     "@ensdomains/ens-contracts": "0.0.4",
-    "@ew-did-registry/proxyidentity": "^0.7.1-alpha.795.0",
+    "@ew-did-registry/proxyidentity": "0.7.1-alpha.795.0",
     "@openzeppelin/contracts": "4.3.3",
     "@openzeppelin/contracts-upgradeable": "4.3.3",
     "@openzeppelin/truffle-upgrades": "1.12.0",

--- a/packages/onchain-claims/package.json
+++ b/packages/onchain-claims/package.json
@@ -45,15 +45,15 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "@energyweb/credential-governance": "2.2.0",
-    "@ew-did-registry/did": "^0.7.1-alpha.795.0",
-    "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
+    "@ew-did-registry/did": "0.7.1-alpha.795.0",
+    "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.795.0",
     "@poanet/solidity-flattener": "^3.0.7",
     "ethers": "^5.7.0"
   },
   "devDependencies": {
     "@ensdomains/buffer": "0.0.13",
     "@ensdomains/ens-contracts": "0.0.4",
-    "@ew-did-registry/proxyidentity": "^0.7.1-alpha.795.0",
+    "@ew-did-registry/proxyidentity": "0.7.1-alpha.795.0",
     "@openzeppelin/contracts": "4.3.3",
     "@openzeppelin/contracts-upgradeable": "4.3.3",
     "@openzeppelin/truffle-upgrades": "1.12.0",

--- a/packages/vc-verification/package.json
+++ b/packages/vc-verification/package.json
@@ -38,12 +38,12 @@
   "dependencies": {
     "@energyweb/credential-governance": "2.2.0",
     "@energyweb/onchain-claims": "2.2.0",
-    "@ew-did-registry/claims": "^0.7.1-alpha.795.0",
-    "@ew-did-registry/credentials-interface": "^0.7.1-alpha.795.0",
-    "@ew-did-registry/did-ethr-resolver": "^0.7.1-alpha.795.0",
-    "@ew-did-registry/did-ipfs-store": "^0.7.1-alpha.795.0",
-    "@ew-did-registry/did-store-interface": "^0.7.1-alpha.795.0",
-    "@ew-did-registry/revocation": "^0.7.1-alpha.795.0",
+    "@ew-did-registry/claims": "0.7.1-alpha.795.0",
+    "@ew-did-registry/credentials-interface": "0.7.1-alpha.795.0",
+    "@ew-did-registry/did-ethr-resolver": "0.7.1-alpha.795.0",
+    "@ew-did-registry/did-ipfs-store": "0.7.1-alpha.795.0",
+    "@ew-did-registry/did-store-interface": "0.7.1-alpha.795.0",
+    "@ew-did-registry/revocation": "0.7.1-alpha.795.0",
     "ethers": "^5.7.0",
     "ipfs-http-client": "^43.0.0",
     "lodash": "^4.17.21"


### PR DESCRIPTION
- Remove carat from all ew-did-registry packages so that it does not use the latest alpha version published to npm