### PR TITLE
fix: add stack trace to error message

### DIFF
--- a/packages/vc-verification/src/utils/errors.ts
+++ b/packages/vc-verification/src/utils/errors.ts
@@ -25,10 +25,18 @@ export class CredentialRevoked extends Error {
 }
 
 export class RevokerNotAuthorized extends Error {
-  constructor(revoker: string, credential: string, reason?: string) {
+  constructor(
+    revoker: string,
+    credential: string,
+    reason?: string,
+    stack?: string
+  ) {
     let message = `Revoker ${revoker} is not authorized to revoke ${credential}`;
     if (reason) {
       message = message + `: ${reason}`;
+    }
+    if (stack) {
+      message = message + `stack: ${stack}`;
     }
     super(message);
   }

--- a/packages/vc-verification/src/verifier/revocation-verification.ts
+++ b/packages/vc-verification/src/verifier/revocation-verification.ts
@@ -151,7 +151,12 @@ export class RevocationVerification {
           );
         }
       } catch (e) {
-        throw new RevokerNotAuthorized(revoker, role, (<Error>e).message);
+        throw new RevokerNotAuthorized(
+          revoker,
+          role,
+          (<Error>e).message,
+          (<Error>e).stack
+        );
       }
     } else {
       throw new InvalidRevokerType(role, revokers?.revokerType);


### PR DESCRIPTION
- add stack trace to revoker error message to see where .ipfs of undefined is coming from