### PR TITLE
Optimize domain read

### DIFF
--- a/packages/credential-governance/src/domain-hierarchy.ts
+++ b/packages/credential-governance/src/domain-hierarchy.ts
@@ -227,7 +227,7 @@ export class DomainHierarchy {
       console.log(`mem ${maxMem / 1e6} mb`);
     }
 
-    const concurrency = 3;
+    const concurrency = Infinity;
     console.time('domainReader.readName');
     const domains = await pMap(
       this.getLogs(event, concurrency),
@@ -289,14 +289,12 @@ export class DomainHierarchy {
         topics: event.topics || [],
       };
 
-      const logs = await this._provider.getLogs(filter);
+      for (const log of await this._provider.getLogs(filter)) {
+        yield log;
+      }
       currentBlock =
         currentBlock > concurrency ? (currentBlock -= concurrency) : 0;
       console.log(`block ${currentBlock}`);
-
-      for (const log of logs) {
-        yield log;
-      }
     }
   }
 }


### PR DESCRIPTION
Current implementation of domain reading includes unnecessary alocations for intermediate results:
- for raw logs https://github.com/energywebfoundation/ew-credentials/blob/2867b93bda7264c7b36ea89b868a2b151ff34dd2/packages/credential-governance/src/domain-hierarchy.ts#L216
- decoded logs https://github.com/energywebfoundation/ew-credentials/blob/2867b93bda7264c7b36ea89b868a2b151ff34dd2/packages/credential-governance/src/domain-hierarchy.ts#L218

This PR streamifies logs processing meaning that memory allocated only for logs that are used for currently parsed domain. With this change memory usage decreases from 750 mb to 230 mb

The level of simultaneously processed logs is determined by `concurrency` parameter

I am uncertain about optimal concurrency. The bigger the value, the less requests to rpc will be made and synchronization will be faster. But from other side more memory will be allocated for logs and processing tasks. 

Some test results:

| log batch size | number of parallel reads | event  |  time | max mem, mb |
|--------------------|----------------------------------|-------------|--------|---------------|
| Infinity | Infinity | TextChanged | 13.740s |  487 | 
| Infinity | Ininity |  DomainUpdated | 3:52.032 | 881 |
| Infinity | 10 |  TextChanged | 2:45.623 | 240 |
| Infinity | 10 |  DomainUpdated | 49:20.397 | 736 |
| Infinity | 100 |  TextChanged | 23.487s | 343 |
| Infinity | 100 |  DomainUpdated | 7:16.738 | 1042 |
| 25_000 | 100 |  TextChanged | 8:36.913 | 242 |
| 25_000 | 100 |  DomainUpdated | 12:33.312 | 574 |
| 10_000 | 100 | TextChanged | 21:08.535 | 240 |
| 10_000 | 100 | DomainUpdated | 25:13.014 | 589 |
...